### PR TITLE
Refactor the Post object API Response parser

### DIFF
--- a/src/post.py
+++ b/src/post.py
@@ -95,8 +95,36 @@ class Post:
 
         if "BodyIsSummary" in response and response["BodyIsSummary"] is True:
             self._body_is_summary = True
-        else:
-            self._body_is_summary = False
+            
+        elements = {
+            'site': '_post_site',
+            'link': '_post_url',
+            'score': '_post_score',
+            'up_vote_count': "_votes['upvotes']",
+            'down_vote_count': "_votes['downvotes']",
+            'owner': {
+                'display_name': '_user_name',
+                'link': '_user_url',
+                'reputation': '_owner_rep'
+               },
+             'question_id': '_post_id', 
+             'answer_id': '_post_id'
+            }
+        
+        for (key, var) in elements.iterkeys():
+            try:
+                if key == 'owner':
+                    for subkey in elements['owner'].iterkeys():
+                        try:
+                            # code
+                        except:  # Improve this except later
+                            continue  # Go to next subkey
+                    continue  # Go to next key because we're done processing the 'owner' key.
+                
+                # Other keys
+                #code
+            except:  # Improve this except later
+                continue  # Go to next key
 
         if 'site' in response:
             self._post_site = response['site']


### PR DESCRIPTION
This uses a dict that is the static mapping of response elements to internal variables, and the newly-written getitem/setitem methods, to iterate through known / parseable elements in the response, and then gets data from the response and sets it into the internal variables of the Post object using the new setitem methods.

Should there be a KeyError anywhere, it's likely because the API response does *not* have that key, so we just simply move on to the next item in the element map.  As an example, this way, if 'question_id' is present, it'll use that for `self._post_id`, and if not, 'answer_id' will be used; failing that, it falls back to a default value of `"0"` for `_post_id` which was defined in the object itself.